### PR TITLE
Reject future timestamped messages, /messages REST API can now take both physical and logical device ids

### DIFF
--- a/src/python/restapi/RestAPI.py
+++ b/src/python/restapi/RestAPI.py
@@ -519,6 +519,7 @@ async def get_physical_timeseries(
 
             start = end - diff
 
+        msgs = None
         if p_uid is not None:
             msgs = dao.get_physical_timeseries_message(start, end, count, only_timestamp, p_uid=p_uid)
         elif l_uid is not None:

--- a/test/python/test_get_physical_messages.py
+++ b/test/python/test_get_physical_messages.py
@@ -11,7 +11,10 @@ import api.client.DAO as dao
 from pdmodels.Models import PhysicalDevice
 from restapi.RestAPI import app
 
-ts: dt.datetime = tu.now() - dt.timedelta(days=683.0)
+ts: dt.datetime = dateutil.parser.isoparse('2024-05-10T23:00:00Z')
+latest_ts = ts
+earliest_ts = ts
+
 interval = dt.timedelta(minutes=15.0)
 
 timestamps = []
@@ -31,7 +34,7 @@ def create_user():
 
 @pytest.fixture(scope='module')
 def create_msgs():
-    global interval, msgs, pd, timestamps, ts
+    global interval, msgs, pd, timestamps, ts, earliest_ts
 
     logging.info('Generating messages')
 
@@ -44,7 +47,8 @@ def create_msgs():
             msgs.append(msg)
             s = f'{pd.uid}\t{ts.isoformat()}\t{json.dumps(msg)}'
             print(s, file=f)
-            ts = ts + interval
+            ts = ts - interval
+            earliest_ts = ts
 
     with open('/tmp/msgs.json', 'r') as f:
         with dao.get_connection() as conn, conn.cursor() as cursor:
@@ -64,21 +68,19 @@ def test_client(create_user, create_msgs):
 
 
 def test_no_params_no_msgs(test_client):
-    no_msg_pd: PhysicalDevice = dao.create_physical_device(PhysicalDevice(source_name='wombat', name='dummy', source_ids={'x': 1}))
-    response = test_client.get(f'/broker/api/physical/messages/{no_msg_pd.uid}')
-    assert response.status_code == 200
-    assert response.json() == []
+    response = test_client.get(f'/broker/api/messages/')
+    assert response.status_code == 404
 
 
 def test_no_params(test_client):
     # Confirm the default count parameter value is correct, so 65536 of the 65537 messages are returned.
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}')
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid})
     assert response.status_code == 200
     assert response.json() == msgs[:-1]
 
 
 def test_no_params_ts(test_client):
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'only_timestamp': 1})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'only_timestamp': 1})
     assert response.status_code == 200
     for a, b in zip(response.json(), timestamps):
         if a is None:
@@ -89,13 +91,13 @@ def test_no_params_ts(test_client):
 
 def test_count(test_client):
     # Confirm the count parameter works.
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'count': 50})
+    response = test_client.get(f'/broker/api/messages/', params={'p_uid': pd.uid, 'count': 50})
     assert response.status_code == 200
     assert response.json() == msgs[:50]
 
 
 def test_count_ts(test_client):
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'count': 50, 'only_timestamp': 1})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'count': 50, 'only_timestamp': 1})
     assert response.status_code == 200
     for a, b in zip(response.json(), timestamps):
         if a is None:
@@ -105,66 +107,64 @@ def test_count_ts(test_client):
 
 
 def test_start_after_end(test_client):
-    start_ts = ts + interval
-
     # Confirm no messages returned when a start timestamp at or after the last message is used.
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'start': start_ts})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'start': latest_ts})
     assert response.status_code == 200
     assert response.json() == []
 
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'start': timestamps[max_msgs]})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'start': timestamps[0]})
     assert response.status_code == 200
     assert response.json() == []
 
 
 def test_start_gives_gt(test_client):
     # Confirm start time parameter gets the next message greater than, not greater than equal to.
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'start': timestamps[max_msgs - 1]})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'start': timestamps[1]})
     assert response.status_code == 200
-    assert response.json() == [msgs[max_msgs]]
+    assert response.json() == [msgs[0]]
 
 
 def test_invalid_count(test_client):
     # Check the invalid count values.
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'count': -1})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'count': -1})
     assert response.status_code == 422
 
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'count': 0})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'count': 0})
     assert response.status_code == 422
 
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'count': 65537})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'count': 65537})
     assert response.status_code == 422
 
 
 def test_end(test_client):
     # Test the end parameter
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'end': timestamps[0] - interval})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'end': earliest_ts})
     assert response.status_code == 200
     assert response.json() == []
 
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'end': timestamps[0]})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'end': timestamps[-1]})
     assert response.status_code == 200
-    assert response.json() == [msgs[0]]
+    assert response.json() == [msgs[-1]]
 
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'end': timestamps[9]})
+    response = test_client.get(f'/broker/api/messages', params={'p_uid': pd.uid, 'end': timestamps[-9]})
     assert response.status_code == 200
-    assert response.json() == msgs[:10]
+    assert response.json() == msgs[-9:]
 
 
 def test_start_end(test_client):
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'start': timestamps[5], 'end': timestamps[9]})
+    response = test_client.get(f'/broker/api/messages/', params={'p_uid': pd.uid, 'start': timestamps[9], 'end': timestamps[5]})
     assert response.status_code == 200
-    assert response.json() == msgs[6:10]
+    assert response.json() == msgs[5:9]
 
 
 def test_invalid_start_end(test_client):
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'start': timestamps[5], 'end': timestamps[5]})
+    response = test_client.get(f'/broker/api/messages/', params={'p_uid': pd.uid, 'start': timestamps[5], 'end': timestamps[5]})
     assert response.status_code == 422
 
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'start': timestamps[5], 'end': timestamps[4]})
+    response = test_client.get(f'/broker/api/messages/', params={'p_uid': pd.uid, 'start': timestamps[4], 'end': timestamps[5]})
     assert response.status_code == 422
 
 
 def test_invalid_count_end(test_client):
-    response = test_client.get(f'/broker/api/physical/messages/{pd.uid}', params={'count': 1, 'end': timestamps[4]})
+    response = test_client.get(f'/broker/api/messages/', params={'p_uid': pd.uid, 'count': 1, 'end': timestamps[4]})
     assert response.status_code == 422


### PR DESCRIPTION
The logical mapper now drops messages that are timestamped more than 1 hour into the future. This has been done because Wombats occasionally have a bad timestamp and downstream systems then get confused when showing the 'latest' data.

Getting messages via logical device id makes more sense in most cases, so the REST API was changed to allow this.